### PR TITLE
fix(26-hotfix-dashboard): fixing issues with dashboard

### DIFF
--- a/kubernetes/apps/placaron/dashboard/app/api.yaml
+++ b/kubernetes/apps/placaron/dashboard/app/api.yaml
@@ -29,7 +29,6 @@ spec:
       - image: docker.io/andorigna/placaron-dashboard:v0.1.1
         name: dashboard
         imagePullPolicy: IfNotPresent
-        imagePullSecrets: dockerhub-secret
         ports:
           - containerPort: 80
 ---


### PR DESCRIPTION
This pull request includes a small change to the `kubernetes/apps/placaron/dashboard/app/api.yaml` file. The change removes the `imagePullSecrets` line from the dashboard container configuration.

* [`kubernetes/apps/placaron/dashboard/app/api.yaml`](diffhunk://#diff-62c81fd5b80bf767773b1f7d64a49c65a27c4847b1b62ffefaca3d958dac10fbL32): Removed the `imagePullSecrets` line from the dashboard container configuration to simplify the deployment configuration.