### PR TITLE
fix(28-fix-alertmanager): fix alertmanager hosts

### DIFF
--- a/kubernetes/apps/observability/prometheus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus/app/helmrelease.yaml
@@ -61,10 +61,11 @@ spec:
           kubernetes.io/tls-acme: 'true'
 
         hosts:
-          - "alertmanager.${SECRET_DOMAIN}"
+          - host: "alertmanager.${SECRET_DOMAIN}"
+            paths:
+              path: /
+              pathType: Prefix
 
-        path: /
-        pathType: Prefix
         tls:
           - secretName: alertmanager-server-tls
             hosts:


### PR DESCRIPTION
This pull request includes a change to the `kubernetes/apps/observability/prometheus/app/helmrelease.yaml` file to improve the configuration of the `hosts` section for better compatibility and clarity.

Configuration improvements:

* Modified the `hosts` section to use a more structured format, specifying `host` and `paths` explicitly. This change enhances readability and aligns with best practices for Kubernetes configuration.