### PR TITLE
feat(): update url for sops download

### DIFF
--- a/.taskfiles/workstation/Taskfile.yaml
+++ b/.taskfiles/workstation/Taskfile.yaml
@@ -63,11 +63,11 @@ tasks:
         platforms: ['linux/amd64']
       - cmd: |
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl";
-          curl -sSfL -o sops https://github.com/getsops/sops/releases/latest/download/sops-v3.9.1.linux.arm64
+          curl -sSfL -o sops https://github.com/getsops/sops/releases/download/sops-v3.9.1.linux.arm64
         platforms: ['linux/arm64']
       - cmd: chmod +x kubectl sops
       - cmd: curl -sSfL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-      - cmd: curl -sSfL https://github.com/mitsuhiko/minijinja/releases/latest/download/minijinja-cli-installer.sh | bash
+      - cmd: curl -sSfL https://github.com/mitsuhiko/minijinja/releases/download/2.12.0/minijinja-cli-installer.sh | bash
     env:
       MINIJINJA_CLI_INSTALL_DIR: '.'
       MINIJINJA_CLI_UNMANAGED_INSTALL: 'true'

--- a/.taskfiles/workstation/Taskfile.yaml
+++ b/.taskfiles/workstation/Taskfile.yaml
@@ -63,7 +63,7 @@ tasks:
         platforms: ['linux/amd64']
       - cmd: |
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl";
-          curl -sSfL -o sops https://github.com/getsops/sops/releases/download/sops-v3.9.1.linux.arm64
+          curl -sSfL -o sops https://github.com/getsops/sops/releases/download/v3.9.1/sops-v3.9.1.linux.arm64
         platforms: ['linux/arm64']
       - cmd: chmod +x kubectl sops
       - cmd: curl -sSfL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash


### PR DESCRIPTION
This pull request updates the installation scripts for `sops` and `minijinja` in the workstation task configuration to use specific release versions instead of the latest release endpoints. This change improves build reproducibility and stability by ensuring that the same versions are always installed.

Dependency installation version pinning:

* Updated the `sops` installation command to download from the specific `v3.9.1` release instead of using the `latest` endpoint, ensuring consistent versioning. (.taskfiles/workstation/Taskfile.yaml)
* Updated the `minijinja` installer script to download from the specific `2.12.0` release instead of using the `latest` endpoint, preventing unexpected version changes. (.taskfiles/workstation/Taskfile.yaml)