### PR TITLE
feat(): adding updated url

### DIFF
--- a/.taskfiles/workstation/Taskfile.yaml
+++ b/.taskfiles/workstation/Taskfile.yaml
@@ -59,11 +59,11 @@ tasks:
         cmd: curl -fsSL "https://i.jpillora.com/{{.ITEM}}&type=script" | bash
       - cmd: |
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl";
-          curl -sSfL -o sops https://github.com/getsops/sops/releases/latest/download/sops-v3.9.1.linux.amd64
+          curl -sSfL -o sops https://github.com/getsops/sops/releases/download/v3.10.2/sops-v3.10.2.linux.amd64
         platforms: ['linux/amd64']
       - cmd: |
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl";
-          curl -sSfL -o sops https://github.com/getsops/sops/releases/download/v3.9.1/sops-v3.9.1.linux.arm64
+          curl -sSfL -o sops https://github.com/getsops/sops/releases/download/v3.10.2/sops-v3.10.2.linux.amd64
         platforms: ['linux/arm64']
       - cmd: chmod +x kubectl sops
       - cmd: curl -sSfL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash


### PR DESCRIPTION
This pull request updates the version of the `sops` binary installed by the workstation setup tasks, ensuring that a newer and more secure version is used for both `linux/amd64` and `linux/arm64` platforms.

Dependency version update:

* Updated the `sops` download URLs in `.taskfiles/workstation/Taskfile.yaml` to use version `v3.10.2` instead of `v3.9.1` for both `linux/amd64` and `linux/arm64` platforms.